### PR TITLE
Configure sane values for days until stale, and days until close for this repo's GitHub Stale Bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,8 +19,8 @@ jobs:
           stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          days-before-stale: 10
-          days-before-close: 1
+          days-before-stale: 730
+          days-before-close: 5
           exempt-issue-labels: 'pinned'
           exempt-pr-labels: 'awaiting-approval,work-in-progress'
           remove-stale-when-updated: true


### PR DESCRIPTION
### Problem:

﻿The users of this repo are often very frustrated, when their carefully opened issues are marked stale after 10 days and then closed.

Users who take the time to report bugs and request features, should be rewarded and appreciated for their interest and commitment, not penalized for it by having their issues rapidly closed as completed, as if they were fixed when they aren't.

Further, it can make SwitchBot customers get the very strong impression that the API is not maintained, or that the API maintainers are completely disinterested in open bugs and feature requests.

Additionally, it causes false activity just for the sake of keeping issues open, which makes for unnecessary traffic, and headaches for the users.

Almost no issues seem to be addressed within the 10 days that were configured.
Which is expected, because this value was unreasonable for any busy dev team.

### Solution:

This PR configures the 10 days, to a much more reasonable two years.
Furthermore, it gives five days instead of one day, between the staleness warning and the issue close.

For people not using GitHub every day, it is hard to notice a notification in time after just one day.
On the other hand, even for those with email notifications active, checking email every day is becoming less common.
